### PR TITLE
Invalid option for CheckID 1 of sp_Blitz

### DIFF
--- a/sp_Blitz.sql
+++ b/sp_Blitz.sql
@@ -873,7 +873,7 @@ AS
 
 						IF @Debug IN (1, 2) RAISERROR('Running CheckId [%d].', 0, 1, 1) WITH NOWAIT;
 
-                        IF SERVERPROPERTY('EngineName') <> 8 /* Azure Managed Instances need a special query */
+                        IF SERVERPROPERTY('EngineEdition') <> 8 /* Azure Managed Instances need a special query */
                             BEGIN
 						    INSERT  INTO #BlitzResults
 								    ( CheckID ,


### PR DESCRIPTION
Changed `SERVERPROPERTY('EngineName')` to be `SERVERPROPERTY('EngineEdition')` on Line 876. As far as I can tell, "EngineName" is an invalid option that always returns `NULL`. This causes the `IF` condition to always use the `ELSE` portion, which should only be used for "Azure Managed Instance"s. According to the documentation for the "[SERVERPROPERTY](https://docs.microsoft.com/en-us/sql/t-sql/functions/serverproperty-transact-sql)" function, it's the "EngineEdition" option that returns "8" for "Azure Managed Instance". Changing this on my system gets this to work as expected.